### PR TITLE
Add redirect index and fix restart button

### DIFF
--- a/BS/game.js
+++ b/BS/game.js
@@ -224,8 +224,7 @@ function bossDefeated() {
 // =====================
 function gameOver() {
   isGameOver = true;
-  showMessage(`ゲームオーバー<br><button id="restartBtn">リトライ</button>`);
-  document.getElementById('restartBtn').onclick = () => init(1);
+  location.href = 'gameover.html';
 }
 
 // =====================

--- a/BS/gameover.html
+++ b/BS/gameover.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ゲームオーバー</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="info"></div>
+  <div id="gameArea">
+    <div id="msg">ゲームオーバー<br><button id="retryBtn">リトライ</button></div>
+  </div>
+  <script>
+    document.getElementById('retryBtn').onclick = () => {
+      location.href = 'index.html';
+    };
+  </script>
+</body>
+</html>

--- a/BS/style.css
+++ b/BS/style.css
@@ -69,7 +69,6 @@ body {
     left: 0;
     z-index: 10;
     text-shadow: 1px 1px 3px #000;
-    pointer-events: none;
   }
   #nextStageBtn, #restartBtn {
     font-size: 1.2rem;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Boss Shooting Game
+
+All game assets and code are located under the `BS/` directory. The root `index.html` simply redirects to `BS/index.html`.
+
+When the player loses, the game navigates to `BS/gameover.html`, where a retry button links back to the main game.
+
+Open `index.html` or navigate directly to `BS/index.html` to play the game.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Boss Shooting</title>
+  <meta http-equiv="refresh" content="0; url=BS/index.html">
+</head>
+<body>
+  <p>If you are not redirected automatically, <a href="BS/index.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root-level redirecting index.html
- document folder layout in README
- allow restart after game over by removing pointer-events on `#msg`
- create dedicated game over screen and navigate to it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843dd97714883239952c904c4359da0