### PR TITLE
Add mobile controls

### DIFF
--- a/BS/game.js
+++ b/BS/game.js
@@ -18,6 +18,9 @@ let canShoot = true;
 const gameArea = document.getElementById('gameArea');
 const info = document.getElementById('info');
 const msg = document.getElementById('msg');
+const leftBtn = document.getElementById('leftBtn');
+const rightBtn = document.getElementById('rightBtn');
+const shootBtn = document.getElementById('shootBtn');
 
 // ゲーム状態
 let player = {};
@@ -242,6 +245,20 @@ document.addEventListener('keydown', e => {
 document.addEventListener('keyup', e => {
   keys[e.key] = false;
 });
+
+function bindButton(btn, key) {
+  if (!btn) return;
+  ['mousedown', 'touchstart'].forEach(ev => {
+    btn.addEventListener(ev, e => { e.preventDefault(); keys[key] = true; });
+  });
+  ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(ev => {
+    btn.addEventListener(ev, e => { e.preventDefault(); keys[key] = false; });
+  });
+}
+
+bindButton(leftBtn, 'ArrowLeft');
+bindButton(rightBtn, 'ArrowRight');
+bindButton(shootBtn, ' ');
 
 // =====================
 // ゲーム開始

--- a/BS/index.html
+++ b/BS/index.html
@@ -10,6 +10,11 @@
   <div id="gameArea">
     <div id="msg"></div>
   </div>
+  <div id="controls">
+    <button id="leftBtn">◀</button>
+    <button id="shootBtn">●</button>
+    <button id="rightBtn">▶</button>
+  </div>
   <script src="stages/stage1.js"></script>
   <script src="stages/stage2.js"></script>
   <script src="stages/stage3.js"></script>

--- a/BS/style.css
+++ b/BS/style.css
@@ -81,3 +81,19 @@ body {
     cursor: pointer;
     box-shadow: 1px 1px 3px #0007;
   }
+
+  #controls {
+    width: 400px;
+    margin: 10px auto;
+    text-align: center;
+  }
+  #controls button {
+    width: 80px;
+    height: 40px;
+    margin: 0 10px;
+    font-size: 1.2rem;
+    border-radius: 8px;
+    border: none;
+    background: #48f;
+    color: #fff;
+  }

--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@ All game assets and code are located under the `BS/` directory. The root `index.
 
 Open `index.html` or navigate directly to `BS/index.html` to play the game.
 
+The in-game controls work with the keyboard or the on-screen buttons,
+allowing play on mobile devices as well.
+
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add on-screen control buttons to play on mobile devices
- style the new controls
- wire up touch/mouse handlers
- document mobile-friendly controls

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6843e61ebc3c83239253ad7fb13da1a5