### PR TITLE
Fix message element handling on stage reset

### DIFF
--- a/BS/game.js
+++ b/BS/game.js
@@ -17,7 +17,7 @@ let canShoot = true;
 // DOM取得
 const gameArea = document.getElementById('gameArea');
 const info = document.getElementById('info');
-const msg = document.getElementById('msg');
+let msg = document.getElementById('msg');
 
 // ゲーム状態
 let player = {};
@@ -31,6 +31,7 @@ let keys = {};
 // =====================
 function init(stageNum=1) {
   gameArea.innerHTML = '<div id="msg"></div>';
+  msg = document.getElementById('msg');
   msg.textContent = "";
   bullets = [];
   enemyBullets = [];


### PR DESCRIPTION
## Summary
- allow reassigning `msg` element
- ensure `msg` gets re-selected after clearing the game area

## Testing
- `node test.js` *(checks stage and restart messages)*

------
https://chatgpt.com/codex/tasks/task_e_6843e66656548323a4325e2857f9c83f