### PR TITLE
Add video background to start screen

### DIFF
--- a/BS/index.html
+++ b/BS/index.html
@@ -7,6 +7,9 @@
 </head>
 <body>
   <div id="startScreen">
+    <video id="startVideo" autoplay muted loop playsinline>
+      <source src="../25CCE318-AE73-48BE-9DF5-D763ABD298D9.mov" type="video/quicktime">
+    </video>
     <h1>Boss Shooting Game</h1>
     <button id="startBtn" aria-label="ゲームスタート">ゲームスタート</button>
   </div>

--- a/BS/style.css
+++ b/BS/style.css
@@ -94,7 +94,19 @@ body {
     justify-content: center;
     color: #eee;
     font-family: sans-serif;
+    position: relative;
+    overflow: hidden;
   }
+
+#startVideo {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
+}
 
 #startBtn {
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- integrate a looped MOV video on the start screen
- style the new video background

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843f23fe3a88323a9cc3fc2c6ca66fc