### PR TITLE
Enhance start screen and mobile controls

### DIFF
--- a/BS/style.css
+++ b/BS/style.css
@@ -83,11 +83,11 @@ body {
   }
 
   #startScreen {
-    width: 400px;
-    height: 600px;
-    margin: 20px auto;
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
     background: #222;
-    border: 4px solid #555;
+    border: none;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -106,6 +106,12 @@ body {
   height: 100%;
   object-fit: cover;
   z-index: -1;
+}
+
+#startScreen h1,
+#startBtn {
+  position: relative;
+  z-index: 1;
 }
 
 #startBtn {
@@ -127,9 +133,9 @@ body {
 }
 
 #touchControls button {
-  width: 80px;
-  height: 80px;
-  font-size: 2rem;
+  width: 120px;
+  height: 120px;
+  font-size: 3rem;
   margin: 0 10px;
   border-radius: 50%;
   border: none;


### PR DESCRIPTION
## Summary
- ensure start screen elements sit above the looping video
- enlarge touch control buttons for mobile
- display start screen video full-screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68440bcb0fb08323ab0d8a5bed5d64a1